### PR TITLE
Change Logger to Apache Commons Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${sl4j-version}</version>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons.logging.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -141,7 +141,6 @@
                             com.squareup.okio.*,
                             com.squareup.okhttp.*,
                             com.google.gson.*;version=${gson-version},
-                            org.slf4j.*;version=${sl4j-version},
                             org.joda.time.*;version=${jodatime-version}
                         </Export-Package>
                         <Import-Package>
@@ -357,7 +356,7 @@
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>
         <jodatime-version>2.9.9</jodatime-version>
-        <sl4j-version>1.7.25</sl4j-version>
+        <commons.logging.version>1.2</commons.logging.version>
         <charon.version>3.0.0</charon.version>
         <commons.logging.version>1.1</commons.logging.version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/src/main/java/org/wso2/scim2/operation/AbstractOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/AbstractOperations.java
@@ -21,8 +21,8 @@ import io.scim2.swagger.client.ScimApiException;
 import io.scim2.swagger.client.ScimApiResponse;
 import io.scim2.swagger.client.api.Scimv2GroupsApi;
 import io.scim2.swagger.client.api.Scimv2UsersApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.charon3.core.config.CharonConfiguration;
 import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
@@ -45,7 +45,7 @@ public abstract class AbstractOperations {
     public static final String USER_FILTER = "userName%20Eq%20";
     public static final String GROUP_FILTER = "displayName%20Eq%20";
 
-    private static Logger logger = LoggerFactory.getLogger(AbstractOperations.class.getName());
+    private static Log logger = LogFactory.getLog(AbstractOperations.class.getName());
 
     protected SCIMObject scimObject;
     protected SCIMProvider provider;

--- a/src/main/java/org/wso2/scim2/operation/AbstractOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/AbstractOperations.java
@@ -45,7 +45,7 @@ public abstract class AbstractOperations {
     public static final String USER_FILTER = "userName%20Eq%20";
     public static final String GROUP_FILTER = "displayName%20Eq%20";
 
-    private static Log logger = LogFactory.getLog(AbstractOperations.class.getName());
+    private static final Log logger = LogFactory.getLog(AbstractOperations.class.getName());
 
     protected SCIMObject scimObject;
     protected SCIMProvider provider;

--- a/src/main/java/org/wso2/scim2/operation/GroupOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/GroupOperations.java
@@ -19,8 +19,8 @@ package org.wso2.scim2.operation;
 import io.scim2.swagger.client.ScimApiException;
 import io.scim2.swagger.client.ScimApiResponse;
 import io.scim2.swagger.client.api.Scimv2GroupsApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.objects.Group;
@@ -40,7 +40,7 @@ import java.util.Map;
 
 public class GroupOperations extends AbstractOperations {
 
-    private static Logger logger = LoggerFactory.getLogger(UserOperations.class.getName());
+    private static Log logger = LogFactory.getLog(UserOperations.class.getName());
 
     public GroupOperations(SCIMProvider scimProvider, SCIMObject object,
                            Map<String, Object> additionalInformation) throws ScimApiException {

--- a/src/main/java/org/wso2/scim2/operation/GroupOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/GroupOperations.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 public class GroupOperations extends AbstractOperations {
 
-    private static Log logger = LogFactory.getLog(UserOperations.class.getName());
+    private static final Log logger = LogFactory.getLog(UserOperations.class.getName());
 
     public GroupOperations(SCIMProvider scimProvider, SCIMObject object,
                            Map<String, Object> additionalInformation) throws ScimApiException {

--- a/src/main/java/org/wso2/scim2/operation/UserOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/UserOperations.java
@@ -19,8 +19,8 @@ package org.wso2.scim2.operation;
 import io.scim2.swagger.client.ScimApiException;
 import io.scim2.swagger.client.ScimApiResponse;
 import io.scim2.swagger.client.api.Scimv2UsersApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class UserOperations extends AbstractOperations {
 
-    private static Logger logger = LoggerFactory.getLogger(UserOperations.class.getName());
+    private static Log logger = LogFactory.getLog(UserOperations.class.getName());
 
     public UserOperations(SCIMProvider scimProvider, SCIMObject object,
                           Map<String, Object> additionalInformation) throws ScimApiException {

--- a/src/main/java/org/wso2/scim2/operation/UserOperations.java
+++ b/src/main/java/org/wso2/scim2/operation/UserOperations.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class UserOperations extends AbstractOperations {
 
-    private static Log logger = LogFactory.getLog(UserOperations.class.getName());
+    private static final Log logger = LogFactory.getLog(UserOperations.class.getName());
 
     public UserOperations(SCIMProvider scimProvider, SCIMObject object,
                           Map<String, Object> additionalInformation) throws ScimApiException {


### PR DESCRIPTION
This PR adds changes needed to change the logging dependency from SLF4J to apache commons logging. 

**Purpose**
Using SLF4J dependency imported Log4j and produced runtime errors when this dependency is used in the product-IS.

Related Issue: https://github.com/wso2/product-is/issues/14202