### PR TITLE
Bump okio version to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
-            <version>1.9.0</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose
- Bump `Okio` version to 3.6.0

## Related Issue
- https://github.com/wso2/product-is/issues/17755