### PR TITLE
Get the latest versions of okio

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,7 +1,7 @@
 # This workflow will build the project on pull requests with tests
 # Uses:
 #   OS: ubuntu-lates
-#   JDK: Adopt JDK 17
+#   JDK: Adopt JDK 8
 
 name: PR Builder
 
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 17
+      - name: Set up Adopt JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: "17"
+          java-version: "8"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>3.9.0</version>
+            <version>${okio.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang.wso2</groupId>
@@ -372,6 +372,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.15</swagger-core-version>
+        <okio.version>3.9.1</okio.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <httpclient.orbit.version>4.5.13.wso2v1</httpclient.orbit.version>
         <httpcore.orbit.version>4.4.16.wso2v1</httpcore.orbit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -386,5 +387,6 @@
         <junit-version>4.12</junit-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sourceReleaseAssemblyDescriptor>source-release</sourceReleaseAssemblyDescriptor>
+        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
> $subject as this is a new dependency we are introducing, we need to get the latest version.

> Reset the java compiler version to 8 and specify the maven bundle plugin version.

### Related Issues:
- https://github.com/wso2/product-is/issues/21903